### PR TITLE
Tweak inspectors output

### DIFF
--- a/core/inspectors/inspector_wcs_comlib.cpp
+++ b/core/inspectors/inspector_wcs_comlib.cpp
@@ -32,9 +32,9 @@ namespace la
 						LinesTools::FilterParam<LinesTools::FilterType::Tag, std::string_view>("COMLib.Debug"),
 						LinesTools::FilterParam<LinesTools::FilterType::Method, std::string_view>("panic") };
 
-			linesTools.windowIterate({ 0, lines.size() }, filter, [&inspectionCtx](size_t, LogLine, size_t lineIndex)
+			linesTools.windowIterate({ 0, lines.size() }, filter, [&inspectionCtx](size_t, LogLine line, size_t lineIndex)
 			{
-				inspectionCtx.addWarning("Panic / Exception", {}, lineIndex);
+				inspectionCtx.addWarning("Panic / Exception", line.getSectionMsg(), lineIndex);
 				return true;
 			});
 		}

--- a/core/lines_repo.cpp
+++ b/core/lines_repo.cpp
@@ -459,7 +459,7 @@ namespace la
 
 			void addInfo(std::string_view ctx, std::string_view msg) override
 			{
-				if (msg.empty())
+				if (ctx.empty() && msg.empty())
 					return;
 
 				nlohmann::json jInfo;
@@ -471,7 +471,7 @@ namespace la
 
 			void addInfo(std::string_view ctx, std::string_view msg, size_t lineIndex) override
 			{
-				if (msg.empty())
+				if (ctx.empty() && msg.empty())
 					return;
 
 				nlohmann::json jInfo;
@@ -484,7 +484,7 @@ namespace la
 
 			void addInfo(std::string_view ctx, std::string_view msg, LinesTools::LineIndexRange lineRange) override
 			{
-				if (msg.empty())
+				if (ctx.empty() && msg.empty())
 					return;
 
 				nlohmann::json jInfo;
@@ -498,7 +498,7 @@ namespace la
 
 			void addWarning(std::string_view ctx, std::string_view msg) override
 			{
-				if (msg.empty())
+				if (ctx.empty() && msg.empty())
 					return;
 
 				nlohmann::json jWarn;
@@ -510,7 +510,7 @@ namespace la
 
 			void addWarning(std::string_view ctx, std::string_view msg, size_t lineIndex) override
 			{
-				if (msg.empty())
+				if (ctx.empty() && msg.empty())
 					return;
 
 				nlohmann::json jWarn;
@@ -523,7 +523,7 @@ namespace la
 
 			void addWarning(std::string_view ctx, std::string_view msg, LinesTools::LineIndexRange lineRange) override
 			{
-				if (msg.empty())
+				if (ctx.empty() && msg.empty())
 					return;
 
 				nlohmann::json jWarn;


### PR DESCRIPTION
Allowed output without either context or message (but not both).
Print message related to panic / exceptions.