### PR TITLE
Generic bug fixing

### DIFF
--- a/core/commands/cmd_wcs_comlib.cpp
+++ b/core/commands/cmd_wcs_comlib.cpp
@@ -27,11 +27,11 @@ namespace la
 				if (!cb(lines[lineIndex]))
 					continue;
 
-				auto taskId = CommandsCOMLibUtils::taskAtLine(linesTools, lineIndex);
-				if (!taskId.has_value())
+				auto taskLineInfo = CommandsCOMLibUtils::taskAtLine(linesTools, lineIndex);
+				if (!taskLineInfo.has_value())
 					continue;
 
-				auto taskLineIndices = CommandsCOMLibUtils::taskFullExecution(linesTools, taskId.value(), { 0, lines.size() });
+				auto taskLineIndices = CommandsCOMLibUtils::taskFullExecution(linesTools, taskLineInfo.value().taskId, { 0, lines.size() });
 				if (taskLineIndices.empty())
 					continue;
 
@@ -58,10 +58,10 @@ namespace la
 				if (auto [p, ec] = std::from_chars(params.data() + 1, params.data() + params.size(), lineIndex); ec != std::errc())
 					return;
 
-				auto taskId = CommandsCOMLibUtils::taskAtLine(linesTools, lineIndex);
-				if (taskId.has_value())
+				auto taskLineInfo = CommandsCOMLibUtils::taskAtLine(linesTools, lineIndex);
+				if (taskLineInfo.has_value())
 				{
-					auto lineIndices = CommandsCOMLibUtils::taskFullExecution(linesTools, taskId.value(), lineRange);
+					auto lineIndices = CommandsCOMLibUtils::taskFullExecution(linesTools, taskLineInfo.value().taskId, { taskLineInfo.value().firstLineIndex, lineRange.end });
 					resultCtx.addLineIndices(lineIndices);
 				}
 
@@ -129,10 +129,10 @@ namespace la
 				if (auto [p, ec] = std::from_chars(params.data() + 1, params.data() + params.size(), lineIndex); ec != std::errc())
 					return;
 
-				auto httpRequestId = CommandsCOMLibUtils::httpRequestAtLine(linesTools, lineIndex);
-				if (httpRequestId.has_value())
+				auto httpLineInfo = CommandsCOMLibUtils::httpRequestAtLine(linesTools, lineIndex);
+				if (httpLineInfo.has_value())
 				{
-					auto lineIndices = CommandsCOMLibUtils::httpRequestFullExecution(linesTools, httpRequestId.value(), lineRange);
+					auto lineIndices = CommandsCOMLibUtils::httpRequestFullExecution(linesTools, httpLineInfo.value().httpRequestId, { httpLineInfo.value().firstLineIndex, lineRange.end });
 					resultCtx.addLineIndices(lineIndices);
 				}
 

--- a/core/commands/cmd_wcs_comlib_utils.hpp
+++ b/core/commands/cmd_wcs_comlib_utils.hpp
@@ -11,13 +11,24 @@ namespace la
 	class CommandsCOMLibUtils final
 	{
 	public:
+		struct TaskLineInfo {
+			int64_t taskId;
+			size_t firstLineIndex;
+		};
+
+		struct HTTPLineInfo {
+			int64_t httpRequestId;
+			size_t firstLineIndex;
+		};
+
+	public:
 		static std::vector<LinesTools::LineIndexRange> executionsRanges(const LinesTools& linesTools);
 
 		static std::vector<size_t> taskFullExecution(const LinesTools& linesTools, int64_t taskId, LinesTools::LineIndexRange lineRange);
-		static std::optional<int64_t> taskAtLine(const LinesTools& linesTools, size_t lineIndex);
+		static std::optional<TaskLineInfo> taskAtLine(const LinesTools& linesTools, size_t lineIndex);
 
 		static std::vector<size_t> httpRequestFullExecution(const LinesTools& linesTools, int64_t httpRequestId, LinesTools::LineIndexRange lineRange);
-		static std::optional<int64_t> httpRequestAtLine(const LinesTools& linesTools, size_t lineIndex);
+		static std::optional<HTTPLineInfo> httpRequestAtLine(const LinesTools& linesTools, size_t lineIndex);
 	};
 }
 

--- a/core/lines_tools.hpp
+++ b/core/lines_tools.hpp
@@ -14,7 +14,7 @@ namespace la
 	class LinesTools
 	{
 	public:
-		enum class FilterType : int8_t { LogLevel, ThreadId, ThreadName, Tag, Method, Msg };
+		enum class FilterType : int8_t { LogLevel, ThreadId, ThreadName, Tag, Method, Msg, Params };
 
 		template<FilterType TFilterType, class TFilterValue, LogLine::MatchType TFilterValueMatchType = LogLine::MatchType::Exact>
 		class FilterParam;
@@ -50,7 +50,7 @@ namespace la
 		template<FilterType TFilterType, LogLine::MatchType TFilterValueMatchType>
 		class FilterParam<TFilterType, std::string_view, TFilterValueMatchType>
 		{
-			static_assert((TFilterType == FilterType::ThreadName) || (TFilterType == FilterType::Tag) || (TFilterType == FilterType::Method) || (TFilterType == FilterType::Msg));
+			static_assert((TFilterType == FilterType::ThreadName) || (TFilterType == FilterType::Tag) || (TFilterType == FilterType::Method) || (TFilterType == FilterType::Msg) || (TFilterType == FilterType::Params));
 			static_assert((TFilterValueMatchType == LogLine::MatchType::Exact) || (TFilterValueMatchType == LogLine::MatchType::StartsWith) || (TFilterValueMatchType == LogLine::MatchType::EndsWith) || (TFilterValueMatchType == LogLine::MatchType::Contains));
 
 		public:
@@ -68,6 +68,8 @@ namespace la
 					return line.checkSectionMethod<TFilterValueMatchType>(m_value);
 				else if constexpr (TFilterType == FilterType::Msg)
 					return line.checkSectionMsg<TFilterValueMatchType>(m_value);
+				else if constexpr (TFilterType == FilterType::Params)
+					return line.checkSectionParams<TFilterValueMatchType>(m_value);
 				else
 					return false;
 			}

--- a/core/log_line.hpp
+++ b/core/log_line.hpp
@@ -144,6 +144,23 @@ namespace la
 			else
 				return false;
 		}
+
+		template<MatchType TMatchType>
+		bool checkSectionParams(std::string_view params) const noexcept
+		{
+			std::string_view curParams{ data.start + sectionParams.offset, sectionParams.size };
+
+			if constexpr (TMatchType == MatchType::Exact)
+				return (curParams == params);
+			else if constexpr (TMatchType == MatchType::StartsWith)
+				return ((curParams.size() >= params.size()) && (curParams.compare(0, params.size(), params) == 0));
+			else if constexpr (TMatchType == MatchType::EndsWith)
+				return ((params.size() > curParams.size()) ? false : (curParams.compare(curParams.length() - params.length(), params.length(), params) == 0));
+			else if constexpr (TMatchType == MatchType::Contains)
+				return (curParams.find(params) != std::string_view::npos);
+			else
+				return false;
+		}
 	};
 
 	static_assert(std::is_trivial_v<LogLine>);


### PR DESCRIPTION
Fixed incorrect execution ranges in COMLib inspection.
Fixed choosing the correct task when searching at line with multiple executions.
Added support to search within the line parameters content.